### PR TITLE
Faster method for object ID enumeration for sources that do not support pagination

### DIFF
--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -338,7 +338,7 @@ class EsriDumper(object):
                 oids = sorted(map(int, self._get_layer_oids()))
 
                 for i in range(0, len(oids), page_size):
-                    oid_chunk = oids[i:i+page_size])
+                    oid_chunk = oids[i:i+page_size]
                     page_min = oid_chunk[0]
                     page_max = oid_chunk[-1]
                     query_args = self._build_query_args({


### PR DESCRIPTION
When trying to get the [Medellín data set](https://github.com/openaddresses/openaddresses/pull/2552) to finish, I noticed that for older servers which don't support pagination, pyesridump sends batches of object IDs 100 at a time (regardless of maxRecordCount).

At least for the Medellín server in question, the OID enumeration method of querying seems to be quite slow (was taking 6+ hours to get through 300k records and often failed half-way through). After some brief experimentation, I found that the same could be achieved by sorting the IDs and constructing one range query per batch (WHERE ObjectID >= MIN_ID_IN_BATCH AND ObjectID <= MAX_ID_IN_BATCH), which in my tests was at least an order of magnitude faster and allowed for larger batch sizes.

Not sure if this would break other sources or if there are some versions of ArcGIS which don't support range queries, but if not this could potentially speed up queries to servers running older versions of ArcGIS significantly.