### PR TITLE
Proxied Requests

### DIFF
--- a/esridump/cli.py
+++ b/esridump/cli.py
@@ -32,6 +32,8 @@ def _parse_args(args):
     parser.add_argument("outfile",
         type=argparse.FileType('w'),
         help="Output file name (use - for stdout)")
+    parser.add_argument("--proxy",
+        help="Proxy string to send requests through ie: https://example.com/proxy.ashx?<SERVER>")
     parser.add_argument("--jsonlines",
         action='store_true',
         default=False,
@@ -87,6 +89,7 @@ def main():
         extra_headers=headers,
         fields=requested_fields,
         request_geometry=args.request_geometry,
+        proxy=args.proxy,
         parent_logger=logger)
 
     if args.jsonlines:

--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -30,11 +30,12 @@ class EsriDumper(object):
         try:
             self._logger.debug("Requesting %s with args %s", url, kwargs.get('params') or kwargs.get('data'))
 
-            if self._proxy and kwargs.get('params'):
-                url = self._proxy + url + '?' + urllib.urlencode(kwargs.get('params'))
-                del kwargs['params']
-            elif self._proxy:
+            if self._proxy:
                 url = self._proxy + url
+                
+                if kwargs.get('params'):
+                    url += '?' + urllib.urlencode(kwargs.get('params'))
+                    del kwargs['params']
 
             return requests.request(method, url, timeout=self._http_timeout, **kwargs)
         except requests.exceptions.SSLError:

--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -11,7 +11,7 @@ class EsriDumper(object):
     def __init__(self, url, parent_logger=None,
         extra_query_args=None, extra_headers=None,
         timeout=None, fields=None, request_geometry=True,
-        outSR=None,proxy=None):
+        outSR=None, proxy=None):
         self._layer_url = url
         self._query_params = extra_query_args or {}
         self._headers = extra_headers or {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ funcsigs==1.0.2
 mock==2.0.0
 nose==1.3.7
 pbr==1.10.0
-requests==2.11.0
+requests==2.13.0
 responses==0.5.1
 simplejson==3.8.2
 six==1.10.0

--- a/tests/cli_tests.py
+++ b/tests/cli_tests.py
@@ -63,6 +63,7 @@ class TestEsriDumpCommandlineMain(unittest.TestCase):
         self.parse_return.request_geometry = True
         self.parse_return.headers = []
         self.parse_return.params = []
+        self.parse_return.proxy = None
         self.mock_parseargs.return_value = self.parse_return
 
         self.fake_url = 'http://example.com'


### PR DESCRIPTION
I've been working my way through a ton of potential Michigan sources and seeing a common occurrence of the ArcGIS URL being proxied behind a server which appends the auth token server-side before hitting the actual ArcGIS server.

So a traditional ArcGIS URL Like:
```
http://example.com/arcgis/rest/services/portAddressPoint/FeatureServer/0
```

Is proxied through another server like:

```
https://example.com/proxy.ashx?http://example.com/arcgis/rest/services/portAddressPoint/FeatureServer/0
```

Since the scraper uses the python requests module to add the param: `f=json` it correctly detects the previous `?` and assumes the `f=json` are additional params and appends `&f=json`.

the proxy however expects a double `?` as it simply pops the second half url and passes it along. This results in a failed query.

This PR adds an optional `--proxy` arg to the CLI that allows the scraper to handle double args.