### PR TITLE
Allow overriding the 'where' parameter

### DIFF
--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -32,7 +32,7 @@ class EsriDumper(object):
 
             if self._proxy:
                 url = self._proxy + url
-                
+
                 if kwargs.get('params'):
                     url += '?' + urllib.urlencode(kwargs.get('params'))
                     del kwargs['params']
@@ -51,7 +51,19 @@ class EsriDumper(object):
         else:
             complete_args = {}
 
-        complete_args.update(dict(**self._query_params))
+        override_args = dict(**self._query_params)
+
+        override_where = override_args.get('where')
+        requested_where = query_args.get('where')
+        if override_where and requested_where != '1=1':
+            # AND the where args together if the user is trying to override
+            # the where param and we're trying to get 'all the rows'
+            override_args['where'] = '({}) AND ({})'.format(
+                requested_where,
+                override_where,
+            )
+
+        complete_args.update(override_args)
 
         return complete_args
 

--- a/tests/cli_tests.py
+++ b/tests/cli_tests.py
@@ -31,7 +31,7 @@ class TestEsriDumpCommandlineMain(unittest.TestCase):
         self.responses.start()
 
         self.add_fixture_response(
-            '.*/\?f=json.*',
+            '.*f=json.*',
             'us-ca-carson/us-ca-carson-metadata.json',
             method='GET',
         )
@@ -98,3 +98,12 @@ class TestEsriDumpCommandlineMain(unittest.TestCase):
 
         # jsonlines won't have FeatureCollection wrapper
         self.assertEqual(self.mock_outfile.write.call_count, 12)
+
+    def test_cli_override_where(self):
+        self.parse_return.params = ['where=foo=bar']
+
+        esridump.cli.main()
+
+        self.assertIn('where=foo%3Dbar&', self.responses.calls[2].request.url)
+        self.assertIn('where=%28OBJECTID+%3E%3D+70193+AND+OBJECTID+%3C%3D+70307%29+AND+%28foo%3Dbar%29', self.responses.calls[3].request.body)
+        self.assertEqual(self.mock_outfile.write.call_count, 14)

--- a/tests/cli_tests.py
+++ b/tests/cli_tests.py
@@ -104,6 +104,6 @@ class TestEsriDumpCommandlineMain(unittest.TestCase):
 
         esridump.cli.main()
 
-        self.assertIn('where=foo%3Dbar&', self.responses.calls[2].request.url)
+        self.assertIn('where=foo%3Dbar', self.responses.calls[2].request.url)
         self.assertIn('where=%28OBJECTID+%3E%3D+70193+AND+OBJECTID+%3C%3D+70307%29+AND+%28foo%3Dbar%29', self.responses.calls[3].request.body)
         self.assertEqual(self.mock_outfile.write.call_count, 14)


### PR DESCRIPTION
Fixes #39.

Allow the user to specify a where arg that overrides the existing `1=1` used to get all data. There is a special case so the requests that the app needs to make (mostly for the `objectid` range queries) are merged properly with the user's requested where param.