### PR TITLE
Fixed _build_query_args method when extra_query_args are passed

### DIFF
--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -58,7 +58,7 @@ class EsriDumper(object):
 
         override_where = override_args.get('where')
         requested_where = query_args.get('where')
-        if override_where and requested_where != '1=1':
+        if override_where and requested_where and requested_where != '1=1':
             # AND the where args together if the user is trying to override
             # the where param and we're trying to get 'all the rows'
             override_args['where'] = '({}) AND ({})'.format(


### PR DESCRIPTION
Closes #48 and closes #49.

The issue occurred whenever I passed `extra_query_args` to the EsriDumper that looked like `where="ModifiedDate>'2018-04-29'"`. These `extra_query_args` were later processed inside the `_build_query_args` method and the method would incorrectly result in args: `where=(None) AND ModifiedDate>'2018-04-29'`.

So the PR just adds a check for the `requested_where`.
