### PR TITLE
Cast float=>int for OIDS

### DIFF
--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -432,7 +432,7 @@ class EsriDumper(object):
                     # pause every number of "requests_to_pause", that increase the probability for server response
                     if query_index % self._requests_to_pause == 0:
                         time.sleep(self._pause_seconds)
-                        self._logger.info("pause for {0} seconds".format(self._pause_seconds))
+                        self._logger.info("pause for %s seconds", self._pause_seconds)
                     response = self._request('POST', query_url, headers=headers, data=query_args)
                     data = self._handle_esri_errors(response, "Could not retrieve this chunk of objects")
                     # reset the exception state.

--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -216,7 +216,8 @@ class EsriDumper(object):
         oid_data = self._handle_esri_errors(response, "Could not check min/max values")
         if not oid_data or not oid_data.get('objectIds') or min_value not in oid_data['objectIds'] or max_value not in oid_data['objectIds']:
             raise EsriDownloadError('Server returned invalid min/max')
-        return (min_value, max_value)
+
+        return (int(min_value), int(max_value))
 
     def _get_layer_oids(self):
         query_args = self._build_query_args({
@@ -431,7 +432,7 @@ class EsriDumper(object):
                     # pause every number of "requests_to_pause", that increase the probability for server response
                     if query_index % self._requests_to_pause == 0:
                         time.sleep(self._pause_seconds)
-                        self._logger.info("pause for {0} seconds", self._pause_seconds)
+                        self._logger.info("pause for {0} seconds".format(self._pause_seconds))
                     response = self._request('POST', query_url, headers=headers, data=query_args)
                     data = self._handle_esri_errors(response, "Could not retrieve this chunk of objects")
                     # reset the exception state.


### PR DESCRIPTION
### Context

A small percent of ESRI Servers return a float value for OID, the float simply appending a `.0` to the actual integer.
To date I have not encountered an actual decimal based OID.

Closes: https://github.com/openaddresses/batch/issues/138
Closes: https://github.com/openaddresses/pyesridump/issues/67