### PR TITLE
Don't error on polygon with no geometry

### DIFF
--- a/esridump/esri2geojson.py
+++ b/esridump/esri2geojson.py
@@ -69,6 +69,9 @@ def convert_esri_polygon(esri_geometry):
     rings = esri_geometry.get('rings')
 
     def ensure_closed_ring(ring):
+        if len(ring) <= 0:
+            return ring
+
         first = ring[0]
         last = ring[-1]
 


### PR DESCRIPTION
This fixes the following error:

```
$ esri2geojson https://www.sjmap.org/ArcGIS/rest/services/PublicWorks/PW_Parcels/MapServer/0 san_joaquin.geojson
2022-05-04 20:09:58,651 - cli.esridump - INFO - Built 455 requests using OID enumeration method
2022-05-04 20:10:15,864 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:10:32,760 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:10:47,523 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:11:03,415 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:11:18,427 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:11:33,048 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:11:49,413 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:12:05,455 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:12:21,015 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:12:36,339 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:12:52,463 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:13:07,409 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:13:21,096 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:13:36,366 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:13:50,192 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:14:05,826 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:14:21,040 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:14:36,420 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:14:52,147 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:15:06,793 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:15:21,083 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:15:35,310 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:15:48,341 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:16:01,850 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:16:18,045 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:16:32,918 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:16:49,382 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:17:03,106 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:17:17,447 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:17:31,833 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:17:47,007 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:18:03,182 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:18:18,625 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:18:32,836 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:18:47,387 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:19:01,984 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:19:17,247 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:19:33,547 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:19:49,818 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:20:04,028 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:20:21,394 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:20:35,656 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:20:51,051 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:21:06,166 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:21:22,050 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:21:35,279 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:21:48,943 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:22:05,198 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:22:20,089 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:22:32,769 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:22:45,456 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:23:00,572 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:23:16,182 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:23:32,626 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:23:47,463 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:24:04,181 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:24:19,189 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:24:35,796 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:24:52,322 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:25:07,350 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:25:22,633 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:25:37,393 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:25:51,990 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:26:04,520 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:26:20,984 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:26:39,541 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:26:55,614 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:27:11,453 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:27:28,483 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:27:45,131 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:28:00,058 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:28:16,167 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:28:35,702 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:28:49,986 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:29:08,055 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:29:28,867 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:29:43,974 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:29:59,892 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:30:15,102 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:30:32,367 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:30:53,321 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:31:11,230 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:31:28,904 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:31:47,549 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:32:00,707 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:32:17,090 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:32:33,839 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:32:50,371 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:33:10,830 - cli.esridump - INFO - pause for 10 seconds
2022-05-04 20:33:31,420 - cli.esridump - INFO - pause for 10 seconds
Traceback (most recent call last):
  File "/opt/homebrew/bin/esri2geojson", line 8, in <module>
    sys.exit(main())
  File "/opt/homebrew/lib/python3.9/site-packages/esridump/cli.py", line 117, in main
    feature = next(feature_iter)
  File "/opt/homebrew/lib/python3.9/site-packages/esridump/dumper.py", line 462, in __iter__
    yield esri2geojson(feature)
  File "/opt/homebrew/lib/python3.9/site-packages/esridump/esri2geojson.py", line 6, in esri2geojson
    geojson_geometry = convert_esri_geometry(esrijson_feature.get('geometry'))
  File "/opt/homebrew/lib/python3.9/site-packages/esridump/esri2geojson.py", line 26, in convert_esri_geometry
    return convert_esri_polygon(esri_geometry)
  File "/opt/homebrew/lib/python3.9/site-packages/esridump/esri2geojson.py", line 85, in convert_esri_polygon
    clean_rings = [
  File "/opt/homebrew/lib/python3.9/site-packages/esridump/esri2geojson.py", line 86, in <listcomp>
    ensure_closed_ring(ring)
  File "/opt/homebrew/lib/python3.9/site-packages/esridump/esri2geojson.py", line 72, in ensure_closed_ring
    first = ring[0]
IndexError: list index out of range
```