### PR TITLE
add state management to the dumper to ease resumption

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 requests = "*"
+jsonschema = "*"
 esridump = {editable = true, path = "."}
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5eaca7d9284739c3acfd74120b9391bef39f76705dfea371ea673e5bf016e236"
+            "sha256": "826bae70c3cc6dc13802940b8c64af0897da8c084e00fd1b705ce358c991830c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -14,20 +14,29 @@
         ]
     },
     "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==22.1.0"
+        },
         "certifi": {
             "hashes": [
-                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
-                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
+                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
-            "version": "==2021.10.8"
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.9.24"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
-                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
+                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
+                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_version >= '3'",
-            "version": "==2.0.12"
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==2.1.1"
         },
         "esridump": {
             "editable": true,
@@ -35,19 +44,78 @@
         },
         "idna": {
             "hashes": [
-                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
-                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
-            "markers": "python_version >= '3'",
-            "version": "==3.3"
+            "markers": "python_version >= '3.5'",
+            "version": "==3.4"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:da31db32b304314d044d3c12c79bd59e307889b287ad12ff387b3500835fc2ab",
+                "sha256:ddb0e35065e8938f867ed4928d0ae5bf2a53b7773871bfe6bcc7e4fcdc7dea43"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==5.0.0"
+        },
+        "importlib-resources": {
+            "hashes": [
+                "sha256:c01b1b94210d9849f286b86bb51bcea7cd56dde0600d8db721d7b81330711668",
+                "sha256:ee17ec648f85480d523596ce49eae8ead87d5631ae1551f913c0100b5edd3437"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==5.10.0"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:165059f076eff6971bae5b742fc029a7b4ef3f9bcf04c14e4776a7605de14b23",
+                "sha256:9e74b8f9738d6a946d70705dc692b74b5429cd0960d58e79ffecfc43b2221eb9"
+            ],
+            "index": "pypi",
+            "version": "==4.16.0"
+        },
+        "pkgutil-resolve-name": {
+            "hashes": [
+                "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174",
+                "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==1.3.10"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c",
+                "sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc",
+                "sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e",
+                "sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26",
+                "sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec",
+                "sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286",
+                "sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045",
+                "sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec",
+                "sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8",
+                "sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c",
+                "sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca",
+                "sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22",
+                "sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a",
+                "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96",
+                "sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc",
+                "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1",
+                "sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07",
+                "sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6",
+                "sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b",
+                "sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5",
+                "sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.18.1"
         },
         "requests": {
             "hashes": [
-                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
-                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
             "index": "pypi",
-            "version": "==2.27.1"
+            "version": "==2.28.1"
         },
         "six": {
             "hashes": [
@@ -57,31 +125,47 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
+                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==4.4.0"
+        },
         "urllib3": {
             "hashes": [
-                "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
-                "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
+                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
+                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.9"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "version": "==1.26.12"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:3a7af91c3db40ec72dd9d154ae18e008c69efe8ca88dde4f9a731bb82fe2f9eb",
+                "sha256:972cfa31bc2fedd3fa838a51e9bc7e64b7fb725a8c00e7431554311f180e9980"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==3.9.0"
         }
     },
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
-                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.4.0"
+            "markers": "python_version >= '3.5'",
+            "version": "==22.1.0"
         },
         "autopep8": {
             "hashes": [
-                "sha256:44f0932855039d2c15c4510d6df665e4730f2b8582704fa48f9c55bd3e17d979",
-                "sha256:ed77137193bbac52d029a52c59bec1b0629b5a186c495f1eb21b126ac466083f"
+                "sha256:6f09e90a2be784317e84dc1add17ebfc7abe3924239957a37e5040e27d812087",
+                "sha256:ca9b1a83e53a7fad65d731dc7a2a2d50aa48f43850407c59f6a1a306c4201142"
             ],
             "index": "pypi",
-            "version": "==1.6.0"
+            "version": "==1.7.0"
         },
         "bump2version": {
             "hashes": [
@@ -101,18 +185,19 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
-                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
+                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
-            "version": "==2021.10.8"
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.9.24"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
-                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
+                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
+                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_version >= '3'",
-            "version": "==2.0.12"
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==2.1.1"
         },
         "cookies": {
             "hashes": [
@@ -124,11 +209,19 @@
         },
         "idna": {
             "hashes": [
-                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
-                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
-            "markers": "python_version >= '3'",
-            "version": "==3.3"
+            "markers": "python_version >= '3.5'",
+            "version": "==3.4"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:da31db32b304314d044d3c12c79bd59e307889b287ad12ff387b3500835fc2ab",
+                "sha256:ddb0e35065e8938f867ed4928d0ae5bf2a53b7773871bfe6bcc7e4fcdc7dea43"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==5.0.0"
         },
         "iniconfig": {
             "hashes": [
@@ -180,43 +273,43 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
-                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+                "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785",
+                "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==2.8.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.9.1"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
-                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
             ],
             "markers": "python_full_version >= '3.6.8'",
-            "version": "==3.0.8"
+            "version": "==3.0.9"
         },
         "pytest": {
             "hashes": [
-                "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c",
-                "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"
+                "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
+                "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
             ],
             "index": "pypi",
-            "version": "==7.1.2"
+            "version": "==7.1.3"
         },
         "requests": {
             "hashes": [
-                "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
-                "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
             "index": "pypi",
-            "version": "==2.27.1"
+            "version": "==2.28.1"
         },
         "responses": {
             "hashes": [
-                "sha256:18831bc2d72443b67664d98038374a6fa1f27eaaff4dd9a7d7613723416fea3c",
-                "sha256:644905bc4fb8a18fa37e3882b2ac05e610fe8c2f967d327eed669e314d94a541"
+                "sha256:396acb2a13d25297789a5866b4881cf4e46ffd49cc26c43ab1117f40b973102e",
+                "sha256:dcf294d204d14c436fddcc74caefdbc5764795a40ff4e6a7740ed8ddbf3294be"
             ],
             "index": "pypi",
-            "version": "==0.20.0"
+            "version": "==0.22.0"
         },
         "toml": {
             "hashes": [
@@ -234,13 +327,36 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
         },
+        "types-toml": {
+            "hashes": [
+                "sha256:8300fd093e5829eb9c1fba69cee38130347d4b74ddf32d0a7df650ae55c2b599",
+                "sha256:b7e7ea572308b1030dc86c3ba825c5210814c2825612ec679eb7814f8dd9295a"
+            ],
+            "version": "==0.10.8"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
+                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==4.4.0"
+        },
         "urllib3": {
             "hashes": [
-                "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
-                "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
+                "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
+                "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.9"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "version": "==1.26.12"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:3a7af91c3db40ec72dd9d154ae18e008c69efe8ca88dde4f9a731bb82fe2f9eb",
+                "sha256:972cfa31bc2fedd3fa838a51e9bc7e64b7fb725a8c00e7431554311f180e9980"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==3.9.0"
         }
     }
 }

--- a/esridump/cli.py
+++ b/esridump/cli.py
@@ -73,8 +73,9 @@ def _parse_args(args):
         help="HTTP timeout in seconds, default 30")
     parser.add_argument("-m", "--max-page-size",
         type=int,
-        default=1000,
-        help="Maximum number of features to pull per batch, default 1000")
+        default=-1,
+        help="Maximum number of features to pull per batch, "
+             "default -1 (means pick from the layer metadata or 1000, whichever is higher)")
     parser.add_argument("--paginate-oid",
         dest='paginate_oid',
         action='store_true',

--- a/esridump/cli.py
+++ b/esridump/cli.py
@@ -175,7 +175,7 @@ def main():
             with open(state_filename, 'w') as f:
                 f.write(dumper._state.encode())
             logger.info('Done saving state file')
-            raise
+        raise
 
 
 if __name__ == '__main__':

--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -64,6 +64,7 @@ class EsriDumper(object):
                  paginate_oid=False, max_page_size=None,
                  state=None, update_state=False,
                  requester=simple_requester, use_only_get=False,
+                 json_arg='json',
                  pause_seconds=10, requests_to_pause=5,
                  num_of_retry=5, output_format='geojson'):
         self._layer_url = url
@@ -85,6 +86,7 @@ class EsriDumper(object):
         self._update_state = update_state
         self._requester = requester
         self._use_only_get = use_only_get 
+        self._json_arg = json_arg
 
         self._pause_seconds = pause_seconds
         self._requests_to_pause = requests_to_pause
@@ -155,7 +157,7 @@ class EsriDumper(object):
             'where': '1=1',
             'returnGeometry': 'false',
             'outFields': ','.join(query_fields),
-            'f': 'json',
+            'f': self._json_arg,
         })
         headers = self._build_headers()
         query_url = self._build_url('/query')
@@ -180,7 +182,7 @@ class EsriDumper(object):
             return self._metadata
 
         query_args = self._build_query_args({
-            'f': 'json',
+            'f': self._json_arg,
         })
         headers = self._build_headers()
         url = self._build_url()
@@ -201,7 +203,7 @@ class EsriDumper(object):
         query_args = self._build_query_args({
             'where': '1=1',
             'returnCountOnly': 'true',
-            'f': 'json',
+            'f': self._json_arg,
         })
         headers = self._build_headers()
         url = self._build_url('/query')
@@ -230,7 +232,7 @@ class EsriDumper(object):
     def _get_layer_min_max(self, oid_field_name):
         """ Find the min and max values for the OID field. """
         query_args = self._build_query_args({
-            'f': 'json',
+            'f': self._json_arg,
             'outFields': '',
             'outStatistics': json.dumps([
                 dict(statisticType='min', onStatisticField=oid_field_name,
@@ -261,7 +263,7 @@ class EsriDumper(object):
                 max_value
             ),
             'returnIdsOnly': 'true',
-            'f': 'json',
+            'f': self._json_arg,
         })
         headers = self._build_headers()
         url = self._build_url('/query')
@@ -278,7 +280,7 @@ class EsriDumper(object):
         query_args = self._build_query_args({
             'where': '1=1',  # So we get everything
             'returnIdsOnly': 'true',
-            'f': 'json',
+            'f': self._json_arg,
         })
         url = self._build_url('/query')
         headers = self._build_headers()
@@ -301,7 +303,7 @@ class EsriDumper(object):
             'returnGeometry': self._request_geometry,
             'outSR': self._outSR,
             'outFields': '*',
-            'f': 'json'
+            'f': self._json_arg,
         })
         headers = self._build_headers()
         url = self._build_url('/query')
@@ -379,7 +381,7 @@ class EsriDumper(object):
             'outFields': ','.join(query_fields or ['*']),
             'returnGeometry': self._request_geometry,
             'outSR': self._outSR,
-            'f': 'json',
+            'f': self._json_arg,
         })
         headers = self._build_headers()
         url = self._build_url('/query')
@@ -482,7 +484,7 @@ class EsriDumper(object):
                     'returnGeometry': self._request_geometry,
                     'outSR': self._outSR,
                     'outFields': ','.join(query_fields or ['*']),
-                    'f': 'json',
+                    'f': self._json_arg,
                 })
                 page_args.append(query_args)
         elif mode is DumperMode.OID_WHERE_CLAUSE:
@@ -500,7 +502,7 @@ class EsriDumper(object):
                     'returnGeometry': self._request_geometry,
                     'outSR': self._outSR,
                     'outFields': ','.join(query_fields or ['*']),
-                    'f': 'json',
+                    'f': self._json_arg,
                 })
                 page_args.append(query_args)
         elif mode is DumperMode.OID_ENUMERATION:
@@ -520,7 +522,7 @@ class EsriDumper(object):
                     'returnGeometry': self._request_geometry,
                     'outSR': self._outSR,
                     'outFields': ','.join(query_fields or ['*']),
-                    'f': 'json',
+                    'f': self._json_arg,
                 })
                 page_args.append(query_args)
         else:

--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -7,6 +7,8 @@ from six.moves.urllib.parse import urlencode
 
 from esridump import esri2geojson
 from esridump.errors import EsriDownloadError
+from esridump.state import DumperMode, DumperState, GeoQuery
+
 
 
 class EsriDumper(object):
@@ -15,7 +17,10 @@ class EsriDumper(object):
                  timeout=None, fields=None, request_geometry=True,
                  outSR=None, proxy=None,
                  start_with=None, geometry_precision=None,
-                 paginate_oid=False, max_page_size=None,
+                 paginate_oid=False,
+                 max_page_size=None,
+                 state=None,
+                 update_state=False,
                  pause_seconds=10, requests_to_pause=5,
                  num_of_retry=5, output_format='geojson'):
         self._layer_url = url
@@ -30,6 +35,11 @@ class EsriDumper(object):
         self._precision = geometry_precision or 7
         self._paginate_oid = paginate_oid
         self._max_page_size = max_page_size or 1000
+        self._page_size = None
+        self._state = state
+        self._query_index = 1
+        self._metadata = None
+        self._update_state = update_state
 
         self._pause_seconds = pause_seconds
         self._requests_to_pause = requests_to_pause
@@ -147,6 +157,13 @@ class EsriDumper(object):
         return data.get('error') and data['error']['message'] != "Failed to execute query."
 
     def get_metadata(self):
+        if self._metadata is not None:
+            return self._metadata
+
+        if self._state is not None:
+            self._metadata = self._state.metadata
+            return self._metadata
+
         query_args = self._build_query_args({
             'f': 'json',
         })
@@ -156,7 +173,14 @@ class EsriDumper(object):
             'GET', url, params=query_args, headers=headers)
         metadata_json = self._handle_esri_errors(
             response, "Could not retrieve layer metadata")
+        self._metadata = metadata_json
         return metadata_json
+
+    def get_page_size(self):
+        if self._page_size is None:
+            metadata = self.get_metadata()
+            self._page_size = max(self._max_page_size, metadata.get('maxRecordCount', 500))
+        return self._page_size
 
     def get_feature_count(self):
         query_args = self._build_query_args({
@@ -214,16 +238,6 @@ class EsriDumper(object):
         min_value = min(min_max_values)
         max_value = max(min_max_values)
         query_args = self._build_query_args({
-            'f': 'json',
-            'outFields': '*',
-            'outStatistics': json.dumps([
-                dict(statisticType='min', onStatisticField=oid_field_name,
-                     outStatisticFieldName='THE_MIN'),
-                dict(statisticType='max', onStatisticField=oid_field_name,
-                     outStatisticFieldName='THE_MAX'),
-            ], separators=(',', ':'))
-        })
-        query_args = self._build_query_args({
             'where': '{} = {} OR {} = {}'.format(
                 oid_field_name,
                 min_value,
@@ -261,7 +275,7 @@ class EsriDumper(object):
             raise EsriDownloadError("Server doesn't support returnIdsOnly")
         return oids
 
-    def _fetch_bounded_features(self, envelope, outSR):
+    def _fetch_bounded_features(self, envelope):
         query_args = self._build_query_args({
             'geometry': json.dumps(envelope),
             'geometryType': 'esriGeometryEnvelope',
@@ -269,17 +283,14 @@ class EsriDumper(object):
             'returnCountOnly': 'false',
             'returnIdsOnly': 'false',
             'returnGeometry': self._request_geometry,
-            'outSR': outSR,
+            'outSR': self._outSR,
             'outFields': '*',
             'f': 'json'
         })
         headers = self._build_headers()
         url = self._build_url('/query')
-        response = self._request(
-            'GET', url, params=query_args, headers=headers)
-        features = self._handle_esri_errors(
-            response, "Could not retrieve a section of features")
-        return features['features']
+        features = self.run_query(url, headers, query_args, verb='GET')
+        return features
 
     def _split_envelope(self, envelope):
         half_width = (envelope['xmax'] - envelope['xmin']) / 2.0
@@ -311,43 +322,78 @@ class EsriDumper(object):
             ),
         ]
 
-    def _scrape_an_envelope(self, envelope, outSR, max_records):
-        features = self._fetch_bounded_features(envelope, outSR)
 
-        if len(features) >= max_records:
-            self._logger.info(
-                "Retrieved exactly the maximum record count. Splitting this box and retrieving the children.")
+    def _scrape_an_envelope(self, envelope, key):
+        explored = self._state.params['explored_tree'].get(key, GeoQuery.NOT_PRESENT.name)
+        explored = GeoQuery[explored]
+        if explored == GeoQuery.EXPLORED:
+            return
 
-            envelopes = self._split_envelope(envelope)
+        max_records = self.get_page_size()
+        if explored in [GeoQuery.OPEN, GeoQuery.NOT_PRESENT]:
+            features = self._fetch_bounded_features(envelope)
+            self._state.update(None, key, GeoQuery.OPEN)
 
-            for child_envelope in envelopes:
-                for feature in self._scrape_an_envelope(child_envelope, outSR, max_records):
+            num_features = len(features)
+            if num_features < max_records:
+                for feature in features:
                     yield feature
-        else:
-            for feature in features:
+                self._state.update(None, key, GeoQuery.EXPLORED)
+                return
+
+        self._logger.info(
+            "Retrieved maximum record count or more records. Splitting this box and retrieving the children.")
+
+        self._state.update(None, key, GeoQuery.SPLIT)
+        envelopes = self._split_envelope(envelope)
+
+        for i, child_envelope in enumerate(envelopes):
+            new_key = f'{key}{i}'
+            for feature in self._scrape_an_envelope(child_envelope, new_key):
                 yield feature
 
-    def __iter__(self):
+        self._state.update(None, key, GeoQuery.EXPLORED)
+
+    def _is_oid_field_returned(self, oid, oid_field_name, query_fields):
+        query_args = self._build_query_args({
+            'where': '{} = {}'.format(
+                oid_field_name,
+                oid,
+            ),
+            'outFields': ','.join(query_fields or ['*']),
+            'returnGeometry': self._request_geometry,
+            'outSR': self._outSR,
+            'f': 'json',
+        })
+        headers = self._build_headers()
+        url = self._build_url('/query')
+        response = self._request('POST', url, data=query_args, headers=headers)
+        data = self._handle_esri_errors(response, f"unable to retrieve feature with {oid}")
+        if data is None or data.get('features') is None or len(data.get('features')) != 1:
+            raise EsriDownloadError('Unable to query for oid field')
+
+        feature = data['features'][0]
+        attrs = feature.get('attributes')
+        if attrs is not None:
+            oid_ret = attrs.get(oid_field_name)
+            if oid_ret == oid:
+                return True
+        return False
+
+
+    def pick_iteration_method(self):
         query_fields = self._fields
         metadata = self.get_metadata()
-        page_size = max(self._max_page_size,
-                        metadata.get('maxRecordCount', 500))
-        geometry_type = metadata.get('geometryType')
 
         row_count = None
-
         try:
             row_count = self.get_feature_count()
+            if row_count == 0:
+                return DumperMode.NO_DATA, (), None
         except EsriDownloadError:
             self._logger.info("Source does not support feature count")
 
-        # If there are no records matching the query, short circuit and return an empty generator.
-        if row_count == 0:
-            return
-            yield
-
-        page_args = []
-
+        query_fields_pagination_support = True
         if not self._paginate_oid and row_count is not None and (metadata.get('supportsPagination') or
                                                                  (metadata.get('advancedQueryCapabilities') and metadata['advancedQueryCapabilities']['supportsPagination'])):
             # If the layer supports pagination, we can use resultOffset/resultRecordCount to paginate
@@ -358,9 +404,58 @@ class EsriDumper(object):
             if query_fields and not self.can_handle_pagination(query_fields):
                 self._logger.info(
                     "Source does not support pagination with fields specified, so querying for all fields.")
-                query_fields = None
+                query_fields_pagination_support = False
+            return DumperMode.RESULT_OFFSET, (self._startWith, row_count, query_fields_pagination_support), None
 
-            for offset in range(self._startWith, row_count, page_size):
+        # If not, we can still use the `where` argument to paginate
+        oid_field_name = self._find_oid_field_name(metadata)
+
+        if not oid_field_name:
+            raise EsriDownloadError(
+                "Could not find object ID field name for deduplication")
+
+        oid_field_returned = None
+        if metadata.get('supportsStatistics'):
+            # If the layer supports statistics, we can request maximum and minimum object ID
+            # to help build the pages
+            try:
+                (oid_min, oid_max) = self._get_layer_min_max(oid_field_name)
+                if self._update_state:
+                    oid_field_returned = self._is_oid_field_returned(oid_min, oid_field_name, query_fields)
+                if oid_field_returned == True or oid_field_returned is None:
+                    return DumperMode.OID_WHERE_CLAUSE, (oid_field_name, oid_min - 1, oid_max), None
+            except EsriDownloadError:
+                self._logger.exception(
+                    "Finding max/min from statistics failed. Trying OID enumeration.")
+
+        try:
+            oids = sorted(map(int, self._get_layer_oids()))
+            if len(oids) == 0:
+                return DumperMode.NO_DATA, (), None
+
+            if self._update_state:
+                if oid_field_returned is None:
+                    oid_field_returned = self._is_oid_field_returned(oids[0], oid_field_name, query_fields)
+            if oid_field_returned is not False:
+                return DumperMode.OID_ENUMERATION, (oid_field_name, oids), None
+        except EsriDownloadError:
+            self._logger.info("Unable to get OID list, Falling back to geo queries", exc_info=True)
+
+        if oid_field_returned is False:
+            raise EsriDownloadError(
+                "Object ID field not returned in queries for deduplication")
+        # Use geospatial queries when none of the ID-based methods will work
+        return DumperMode.GEO_QUERIES, (oid_field_name,), oid_field_returned
+ 
+    def get_page_args(self, mode, rest):
+        page_size = self.get_page_size()
+        query_fields = self._fields
+        page_args = []
+        if mode is DumperMode.RESULT_OFFSET:
+            start_with, row_count, query_fields_pagination_support = rest
+            if not query_fields_pagination_support:
+                query_fields = None
+            for offset in range(start_with, row_count, page_size):
                 query_args = self._build_query_args({
                     'resultOffset': offset,
                     'resultRecordCount': page_size,
@@ -372,141 +467,134 @@ class EsriDumper(object):
                     'f': 'json',
                 })
                 page_args.append(query_args)
-            self._logger.info(
-                "Built %s requests of size %s using resultOffset method", len(page_args), page_size)
+        elif mode is DumperMode.OID_WHERE_CLAUSE:
+            oid_field_name, done_till, oid_max = rest
+            for page_min in range(done_till, oid_max, page_size):
+                page_max = min(page_min + page_size, oid_max)
+                query_args = self._build_query_args({
+                    'where': '{} > {} AND {} <= {}'.format(
+                        oid_field_name,
+                        page_min,
+                        oid_field_name,
+                        page_max,
+                    ),
+                    'geometryPrecision': self._precision,
+                    'returnGeometry': self._request_geometry,
+                    'outSR': self._outSR,
+                    'outFields': ','.join(query_fields or ['*']),
+                    'f': 'json',
+                })
+                page_args.append(query_args)
+        elif mode is DumperMode.OID_ENUMERATION:
+            oid_field_name, oids = rest
+            for i in range(0, len(oids), page_size):
+                oid_chunk = oids[i:i+page_size]
+                page_min = oid_chunk[0]
+                page_max = oid_chunk[-1]
+                query_args = self._build_query_args({
+                    'where': '{} >= {} AND {} <= {}'.format(
+                        oid_field_name,
+                        page_min,
+                        oid_field_name,
+                        page_max,
+                    ),
+                    'geometryPrecision': self._precision,
+                    'returnGeometry': self._request_geometry,
+                    'outSR': self._outSR,
+                    'outFields': ','.join(query_fields or ['*']),
+                    'f': 'json',
+                })
+                page_args.append(query_args)
         else:
-            # If not, we can still use the `where` argument to paginate
+            raise Exception(f'Unexpected mode for prefetching queries: {mode.name}') 
 
-            use_oids = True
-            oid_field_name = self._find_oid_field_name(metadata)
+        return page_args
 
-            if not oid_field_name:
+    def run_query(self, query_url, headers, query_args, verb='POST'):
+        download_exception = None
+        data = None
+
+        request_arg_key = 'data' if verb == 'POST' else 'params'
+        request_args = { request_arg_key: query_args }
+
+        #  try to do a request "num_of_retry" to increase the probability of fetching data successfully
+        for retry in range(self._num_of_retry):
+            try:
+                # pause every number of "requests_to_pause", that increase the probability for server response
+                if self._query_index % self._requests_to_pause == 0:
+                    time.sleep(self._pause_seconds)
+                    self._logger.info(
+                        "pause for %s seconds", self._pause_seconds)
+                response = self._request(verb, query_url, headers=headers, **request_args)
+                data = self._handle_esri_errors(
+                    response, "Could not retrieve this chunk of objects")
+                # reset the exception state.
+                download_exception = None
+                # get out of retry loop, as the request succeeded
+                break
+            except socket.timeout as e:
                 raise EsriDownloadError(
-                    "Could not find object ID field name for deduplication")
+                    "Timeout when connecting to URL", e)
+            except ValueError as e:
+                raise EsriDownloadError("Could not parse JSON", e)
+            except Exception as e:
+                download_exception = EsriDownloadError(
+                    "Could not connect to URL", e)
+                # increase the pause time every retry, to increase the probability of fetching data successfully
+                time.sleep(self._pause_seconds * (retry + 1))
+                self._logger.info("retry pause {0}".format(retry))
 
-            if metadata.get('supportsStatistics'):
-                # If the layer supports statistics, we can request maximum and minimum object ID
-                # to help build the pages
-                try:
-                    (oid_min, oid_max) = self._get_layer_min_max(oid_field_name)
+        if download_exception:
+            raise download_exception
 
-                    for page_min in range(oid_min - 1, oid_max, page_size):
-                        page_max = min(page_min + page_size, oid_max)
-                        query_args = self._build_query_args({
-                            'where': '{} > {} AND {} <= {}'.format(
-                                oid_field_name,
-                                page_min,
-                                oid_field_name,
-                                page_max,
-                            ),
-                            'geometryPrecision': self._precision,
-                            'returnGeometry': self._request_geometry,
-                            'outSR': self._outSR,
-                            'outFields': ','.join(query_fields or ['*']),
-                            'f': 'json',
-                        })
-                        page_args.append(query_args)
-                    self._logger.info(
-                        "Built {} requests using OID where clause method".format(len(page_args)))
+        error = data.get('error')
+        if error:
+            raise EsriDownloadError("Problem querying ESRI dataset with args {}. Server said: {}".format(
+                query_args, error['message']))
 
-                    # If we reach this point we don't need to fall through to enumerating all object IDs
-                    # because the statistics method worked
-                    use_oids = False
-                except EsriDownloadError:
-                    self._logger.exception(
-                        "Finding max/min from statistics failed. Trying OID enumeration.")
+        self._query_index += 1
+        features = data.get('features')
+        return features
 
-            if use_oids:
-                # If the layer does not support statistics, we can request
-                # all the individual IDs and page through them one chunk at
-                # a time.
 
-                try:
-                    oids = sorted(map(int, self._get_layer_oids()))
+    def __iter__(self):
+        metadata = self.get_metadata()
+        if self._state is not None:
+            mode = self._state.mode
+            rest = self._state.get_required_info()
+        else:
+            mode, rest, oid_field_returned = self.pick_iteration_method()
+            self._state = DumperState.get_state(mode, rest, metadata)
 
-                    for i in range(0, len(oids), page_size):
-                        oid_chunk = oids[i:i+page_size]
-                        page_min = oid_chunk[0]
-                        page_max = oid_chunk[-1]
-                        query_args = self._build_query_args({
-                            'where': '{} >= {} AND {} <= {}'.format(
-                                oid_field_name,
-                                page_min,
-                                oid_field_name,
-                                page_max,
-                            ),
-                            'geometryPrecision': self._precision,
-                            'returnGeometry': self._request_geometry,
-                            'outSR': self._outSR,
-                            'outFields': ','.join(query_fields or ['*']),
-                            'f': 'json',
-                        })
-                        page_args.append(query_args)
-                    self._logger.info(
-                        "Built %s requests using OID enumeration method", len(page_args))
-                except EsriDownloadError:
-                    self._logger.info("Falling back to geo queries")
-                    # Use geospatial queries when none of the ID-based methods will work
-                    bounds = metadata['extent']
-                    saved = set()
+        if mode is DumperMode.NO_DATA:
+            return
 
-                    for feature in self._scrape_an_envelope(bounds, self._outSR, page_size):
-                        attrs = feature['attributes']
-                        oid = attrs.get(oid_field_name)
-                        if oid in saved:
-                            continue
+        if mode is DumperMode.GEO_QUERIES:
+            #TODO: check exceededTransferLimit
+            bounds = metadata['extent']
+            for feature in self._scrape_an_envelope(bounds, "0"):
+                if self._state.already_covered(feature):
+                    continue
+                self._state.update(feature)
+                if self._output_format == 'geojson':
+                    yield esri2geojson(feature)
+                else:
+                    yield feature
+            return
 
-                        yield esri2geojson(feature)
-
-                        saved.add(oid)
-
-                    return
+        page_args = self.get_page_args(mode, rest)
+        self._logger.info(
+            "Built {} requests using {} method".format(len(page_args), mode.name))
 
         query_url = self._build_url('/query')
         headers = self._build_headers()
-        for query_index, query_args in enumerate(page_args, start=1):
-            download_exception = None
-            data = None
-
-            #  try to do a request "num_of_retry" to increase the probability of fetching data successfully
-            for retry in range(self._num_of_retry):
-                try:
-                    # pause every number of "requests_to_pause", that increase the probability for server response
-                    if query_index % self._requests_to_pause == 0:
-                        time.sleep(self._pause_seconds)
-                        self._logger.info(
-                            "pause for %s seconds", self._pause_seconds)
-                    response = self._request(
-                        'POST', query_url, headers=headers, data=query_args)
-                    data = self._handle_esri_errors(
-                        response, "Could not retrieve this chunk of objects")
-                    # reset the exception state.
-                    download_exception = None
-                    # get out of retry loop, as the request succeeded
-                    break
-                except socket.timeout as e:
-                    raise EsriDownloadError(
-                        "Timeout when connecting to URL", e)
-                except ValueError as e:
-                    raise EsriDownloadError("Could not parse JSON", e)
-                except Exception as e:
-                    download_exception = EsriDownloadError(
-                        "Could not connect to URL", e)
-                    # increase the pause time every retry, to increase the probability of fetching data successfully
-                    time.sleep(self._pause_seconds * (retry + 1))
-                    self._logger.info("retry pause {0}".format(retry))
-
-            if download_exception:
-                raise download_exception
-
-            error = data.get('error')
-            if error:
-                raise EsriDownloadError("Problem querying ESRI dataset with args {}. Server said: {}".format(
-                    query_args, error['message']))
-
-            features = data.get('features')
-
+        for query_args in page_args:
+            features = self.run_query(query_url, headers, query_args)
             for feature in features:
+                if self._update_state:
+                    #if self._state.already_covered(feature):
+                    #    continue
+                    self._state.update(feature)
                 if self._output_format == 'geojson':
                     yield esri2geojson(feature)
                 else:

--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -10,6 +10,50 @@ from esridump.errors import EsriDownloadError
 from esridump.state import DumperMode, DumperState, GeoQuery
 
 
+def handle_esri_errors(response, logger, error_message, dont_throw_on_error_return):
+    if response.status_code != 200:
+        raise EsriDownloadError('{}: {} HTTP {} {}'.format(
+            response.request.url,
+            error_message,
+            response.status_code,
+            response.text,
+        ))
+
+    try:
+        data = response.json()
+    except:
+        logger.error("Could not parse response from {} as JSON:\n\n{}".format(
+            response.request.url,
+            response.text,
+        ))
+        raise
+
+    if dont_throw_on_error_return:
+        return data
+
+    error = data.get('error')
+    if error:
+        raise EsriDownloadError("{}: {} {}" .format(
+            error_message,
+            error['message'],
+            ', '.join(error['details']),
+        ))
+
+    return data
+
+
+def simple_requester(method, url, logger, timeout, error_message, dont_throw_on_error_return=False, **kwargs):
+    try:
+        logger.debug("%s %s, args %s", method, url, kwargs.get('params') or kwargs.get('data'))
+        resp = requests.request(method, url, timeout=timeout, **kwargs)
+    except requests.exceptions.SSLError:
+        logger.warning("Retrying %s without SSL verification", url)
+        resp = requests.request(method, url, timeout=timeout, verify=False, **kwargs)
+
+    return handle_esri_errors(resp, logger, error_message, dont_throw_on_error_return)
+
+
+
 
 class EsriDumper(object):
     def __init__(self, url, parent_logger=None,
@@ -21,6 +65,7 @@ class EsriDumper(object):
                  max_page_size=None,
                  state=None,
                  update_state=False,
+                 requester=simple_requester,
                  pause_seconds=10, requests_to_pause=5,
                  num_of_retry=5, output_format='geojson'):
         self._layer_url = url
@@ -40,6 +85,7 @@ class EsriDumper(object):
         self._query_index = 1
         self._metadata = None
         self._update_state = update_state
+        self._requester = requester
 
         self._pause_seconds = pause_seconds
         self._requests_to_pause = requests_to_pause
@@ -55,22 +101,13 @@ class EsriDumper(object):
         else:
             self._logger = logging.getLogger('esridump')
 
-    def _request(self, method, url, **kwargs):
-        try:
-
-            if self._proxy:
-                url = self._proxy + url
-
-                params = kwargs.pop('params', None)
-                if params:
-                    url += '?' + urlencode(params)
-
-            self._logger.debug("%s %s, args %s", method, url,
-                               kwargs.get('params') or kwargs.get('data'))
-            return requests.request(method, url, timeout=self._http_timeout, **kwargs)
-        except requests.exceptions.SSLError:
-            self._logger.warning("Retrying %s without SSL verification", url)
-            return requests.request(method, url, timeout=self._http_timeout, verify=False, **kwargs)
+    def _request(self, method, url, error_message, **kwargs):
+        if self._proxy:
+            url = self._proxy + url
+            params = kwargs.pop('params', None)
+            if params:
+                url += '?' + urlencode(params)
+        return self._requester(method, url, self._logger, self._http_timeout, error_message, **kwargs)
 
     def _build_url(self, url=None):
         return self._layer_url + url if url else self._layer_url
@@ -103,33 +140,6 @@ class EsriDumper(object):
             complete_headers.update(headers)
         return complete_headers
 
-    def _handle_esri_errors(self, response, error_message):
-        if response.status_code != 200:
-            raise EsriDownloadError('{}: {} HTTP {} {}'.format(
-                response.request.url,
-                error_message,
-                response.status_code,
-                response.text,
-            ))
-
-        try:
-            data = response.json()
-        except:
-            self._logger.error("Could not parse response from {} as JSON:\n\n{}".format(
-                response.request.url,
-                response.text,
-            ))
-            raise
-
-        error = data.get('error')
-        if error:
-            raise EsriDownloadError("{}: {} {}" .format(
-                error_message,
-                error['message'],
-                ', '.join(error['details']),
-            ))
-
-        return data
 
     def can_handle_pagination(self, query_fields):
         check_args = self._build_query_args({
@@ -142,16 +152,14 @@ class EsriDumper(object):
         })
         headers = self._build_headers()
         query_url = self._build_url('/query')
-        response = self._request(
-            'POST', query_url, headers=headers, data=check_args)
 
         try:
-            data = response.json()
+            data = self._request('POST', query_url,
+                                 "Could not parse response from pagination check as JSON",
+                                 dont_throw_on_error_return=True,
+                                 headers=headers,
+                                 data=check_args)
         except:
-            self._logger.error("Could not parse response from pagination check %s as JSON:\n\n%s",
-                               response.request.url,
-                               response.text,
-                               )
             return False
 
         return data.get('error') and data['error']['message'] != "Failed to execute query."
@@ -169,10 +177,10 @@ class EsriDumper(object):
         })
         headers = self._build_headers()
         url = self._build_url()
-        response = self._request(
-            'GET', url, params=query_args, headers=headers)
-        metadata_json = self._handle_esri_errors(
-            response, "Could not retrieve layer metadata")
+        metadata_json = self._request('GET', url,
+                                      "Could not retrieve layer metadata",
+                                      params=query_args,
+                                      headers=headers)
         self._metadata = metadata_json
         return metadata_json
 
@@ -190,10 +198,10 @@ class EsriDumper(object):
         })
         headers = self._build_headers()
         url = self._build_url('/query')
-        response = self._request(
-            'GET', url, params=query_args, headers=headers)
-        count_json = self._handle_esri_errors(
-            response, "Could not retrieve row count")
+        count_json = self._request('GET', url,
+                                   "Could not retrieve row count",
+                                   params=query_args,
+                                   headers=headers)
         count = count_json.get('count')
         if count is None:
             raise EsriDownloadError("Server doesn't support returnCountOnly")
@@ -226,10 +234,11 @@ class EsriDumper(object):
         })
         headers = self._build_headers()
         url = self._build_url('/query')
-        response = self._request(
-            'GET', url, params=query_args, headers=headers)
-        metadata = self._handle_esri_errors(
-            response, "Could not retrieve min/max oid values")
+
+        metadata = self._request('GET', url,
+                                 "Could not retrieve min/max oid values",
+                                 params=query_args,
+                                 headers=headers)
 
         # Some servers (specifically version 10.11, it seems) will respond with SQL statements
         # for the attribute names rather than the requested field names, so pick the min and max
@@ -249,10 +258,10 @@ class EsriDumper(object):
         })
         headers = self._build_headers()
         url = self._build_url('/query')
-        response = self._request(
-            'GET', url, params=query_args, headers=headers)
-        oid_data = self._handle_esri_errors(
-            response, "Could not check min/max values")
+        oid_data = self._request('GET', url,
+                                 "Could not check min/max values",
+                                 params=query_args,
+                                 headers=headers)
         if not oid_data or not oid_data.get('objectIds') or min_value not in oid_data['objectIds'] or max_value not in oid_data['objectIds']:
             raise EsriDownloadError('Server returned invalid min/max')
 
@@ -266,10 +275,10 @@ class EsriDumper(object):
         })
         url = self._build_url('/query')
         headers = self._build_headers()
-        response = self._request(
-            'GET', url, params=query_args, headers=headers)
-        oid_data = self._handle_esri_errors(
-            response, "Could not retrieve object IDs")
+        oid_data = self._request('GET', url,
+                                 "Could not retrieve object IDs",
+                                 params=query_args,
+                                 headers=headers)
         oids = oid_data.get('objectIds')
         if not oids:
             raise EsriDownloadError("Server doesn't support returnIdsOnly")
@@ -367,8 +376,10 @@ class EsriDumper(object):
         })
         headers = self._build_headers()
         url = self._build_url('/query')
-        response = self._request('POST', url, data=query_args, headers=headers)
-        data = self._handle_esri_errors(response, f"unable to retrieve feature with {oid}")
+        data = self._request('POST', url,
+                             f"unable to retrieve feature with {oid}",
+                             data=query_args,
+                             headers=headers)
         if data is None or data.get('features') is None or len(data.get('features')) != 1:
             raise EsriDownloadError('Unable to query for oid field')
 
@@ -525,9 +536,11 @@ class EsriDumper(object):
                     time.sleep(self._pause_seconds)
                     self._logger.info(
                         "pause for %s seconds", self._pause_seconds)
-                response = self._request(verb, query_url, headers=headers, **request_args)
-                data = self._handle_esri_errors(
-                    response, "Could not retrieve this chunk of objects")
+
+                data = self._request(verb, query_url,
+                                     "Could not retrieve this chunk of objects",
+                                     headers=headers,
+                                     **request_args)
                 # reset the exception state.
                 download_exception = None
                 # get out of retry loop, as the request succeeded

--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -78,7 +78,7 @@ class EsriDumper(object):
         self._startWith = start_with or 0
         self._precision = geometry_precision or 7
         self._paginate_oid = paginate_oid
-        self._max_page_size = max_page_size or 1000
+        self._max_page_size = max_page_size or -1
         self._page_size = None
         self._state = state
         self._query_index = 1
@@ -196,7 +196,17 @@ class EsriDumper(object):
     def get_page_size(self):
         if self._page_size is None:
             metadata = self.get_metadata()
-            self._page_size = max(self._max_page_size, metadata.get('maxRecordCount', 500))
+            layer_max_record_count = metadata.get('maxRecordCount')
+            if self._max_page_size == -1:
+                if layer_max_record_count is not None:
+                    self._page_size = layer_max_record_count
+                else:
+                    self._page_size = 1000
+            else:
+                if layer_max_record_count is None:
+                    self._page_size = self._max_page_size
+                else:
+                    self._page_size = min(self._max_page_size, layer_max_record_count)
         return self._page_size
 
     def get_feature_count(self):

--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -218,14 +218,19 @@ class EsriDumper(object):
 
     def _find_oid_field_name(self, metadata):
         oid_field_name = metadata.get('objectIdField')
-        if not oid_field_name:
-            for f in metadata['fields']:
-                if f.get('type') == 'esriFieldTypeOID':
-                    oid_field_name = f['name']
-                elif f['name'].lower() == 'objectid':
-                    oid_field_name = f['name']
-                else:
-                    break
+
+        if oid_field_name is not None:
+            return oid_field_name
+
+        for f in metadata['fields']:
+            if f.get('type') == 'esriFieldTypeOID':
+                oid_field_name = f['name']
+                return oid_field_name
+
+        for f in metadata['fields']:
+            if f['name'].lower() == 'objectid':
+                oid_field_name = f['name']
+                return oid_field_name
 
         return oid_field_name
 

--- a/esridump/state.py
+++ b/esridump/state.py
@@ -1,0 +1,442 @@
+import json
+from enum import Enum
+from pprint import pformat
+
+import jsonschema
+
+
+class DumperStateMeta(type):
+     def __call__(cls, mode, *args, **kwargs):
+         if cls is DumperState:
+             return mode.value(mode, *args, **kwargs)
+         return type.__call__(cls, mode, *args, **kwargs)
+
+class DumperState(metaclass=DumperStateMeta):
+    __params_schema = None
+
+    def __init__(self, mode, metadata,
+                 params=None,
+                 other_info=None,
+                 **kwargs):
+        self.mode = mode
+        if params is None and other_info is None:
+            raise Exception('one of params or other_info needs to be provided')
+        if params is not None and other_info is not None:
+            raise Exception("both params or other_info can't be be provided")
+
+        if params is not None:
+            self.params = params
+            self.validate_params()
+        else:
+            self.get_params_from_info(other_info)
+        self.metadata = metadata
+
+    def encode(self):
+        return json.dumps({
+            'mode': self.mode.name,
+            'metadata': self.metadata,
+            'params': self.params
+        })
+
+    def get_params_from_info(self, other_info):
+        raise NotImplementedError
+
+    def already_covered(self, feature):
+        raise NotImplementedError
+
+    def update(self, feature, *args):
+        raise NotImplementedError
+
+    def decode(saved_str):
+        data = json.loads(saved_str)
+        mode = DumperMode[data['mode']]
+        params = data['params']
+        metadata = data['metadata']
+        return DumperState(mode, metadata, params=params)
+
+    def get_state(mode, rest, metadata, **kwargs):
+        return DumperState(mode, metadata,
+                           params=None,
+                           other_info=rest,
+                           **kwargs)
+
+    def raise_validation_error(self, msg):
+        raise Exception(f'For {self.mode.name}: {msg}')
+
+    def validate_params(self):
+        schema = self.__class__.__params_schema
+        if schema is None:
+            return
+
+        try:
+            jsonschema.validate(self.params, schema)
+        except jsonschema.exceptions.ValidationError as ex:
+            self.raise_validation_error(ex.message)
+
+    def get_required_info(self):
+        raise NotImplementedError
+
+    def update_from_geojson(self, f):
+        raise NotImplementedError
+
+    def update_state_from_output_file(self, output_file):
+        with open(output_file, 'r') as fp:
+            for line in fp:
+                f = json.loads(line.strip())
+                self.update_from_geojson(f)
+
+    def __str__(self):
+        rep = f'<{self.mode.name}>\n'
+        rep += 'metadata:\n'
+        rep += f'{pformat(self.metadata)}\n'
+        rep += 'params:\n'
+        rep += f'{pformat(self.params)}\n'
+        return rep
+
+    def desc_short(self):
+        rep = f'<{self.mode.name}>\n'
+        return rep
+
+
+class NoDataDumperState(DumperState):
+    def validate_params(self):
+        if len(self.params) != 0:
+            self.raise_validation_error('params expected to be empty')
+
+    def get_params_from_info(self, other_info):
+        self.params = {}
+
+
+class ResultOffsetDumperState(DumperState):
+    __params_schema = {
+        "type" : "object",
+        "required": [ "row_count", "start_with", 'query_args_pagination_support' ],
+        "properties": {
+            "row_count": {
+                "description": "number of records in the layer",
+                "type": "integer",
+                "minimum": 0
+            },
+            "start_with": {
+                "description": "count of records already handled",
+                "type": "integer",
+                "minimum": 0
+            },
+            "query_args_pagination_support": {
+                "description": "whether pagination is supported with query_args enabled",
+                "type": "boolean"
+            }
+        }
+    }
+
+    def validate_params(self):
+        super().validate_params()
+        row_count = self.params['row_count']
+        start_with = self.params['start_with']
+        if start_with >= row_count:
+            self.raise_validation_error(f'{start_with=} is expected to be smaller than {row_count=}')
+
+
+    def get_params_from_info(self, other_info):
+        self.params = {
+            'start_with': other_info[0],
+            'row_count': other_info[1],
+            'query_args_pagination_support': other_info[2]
+        }
+
+    def already_covered(self, feature):
+        return False
+
+    def update(self, feature, *args):
+        self.params['start_with'] += 1
+
+    def update_state_from_output_file(self, output_file):
+        with open(output_file, 'r') as fp:
+            self.params['start_with'] = 0
+            for line in fp:
+                self.params['start_with'] += 1
+
+    def get_required_info(self):
+        return (self.params['start_with'], self.params['row_count'], self.params['query_args_pagination_support'])
+
+    def desc_short(self):
+        desc = super().desc_short()
+        desc += f'params: < {self.params} >\n'
+        return desc
+
+
+class OIDWhereClauseDumperState(DumperState):
+    __params_schema = {
+        "type" : "object",
+        "required": [ "oid_field_name", "oid_min", "oid_max", "done" ],
+        "properties": {
+            "oid_field_name": {
+                "description": "name of the oid field",
+                "type": "string",
+            },
+            "oid_min": {
+                "description": "minimum value of the oid field",
+                "type": "integer",
+            },
+            "oid_max": {
+                "description": "maximum value of the oid field",
+                "type": "integer",
+            },
+            "done": {
+                "description": "oid field values already seen",
+                "type": "array",
+                "items": {
+                    "type": "integer"
+                }
+            }
+        }
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._done = set(self.params['done'])
+        if len(self._done):
+            self._done_till = max(self._done)
+        else:
+            self._done_till = self.params['oid_min'] - 1
+
+    def validate_params(self):
+        super().validate_params()
+        oid_min = self.params['oid_min']
+        oid_max = self.params['oid_max']
+        done = self.params['done']
+        if oid_min > oid_max:
+            self.raise_validation_error(f'{oid_min=} is expected to be smaller than {oid_max=}')
+        greater = [ oid for oid in done if oid > oid_max ]
+        lesser  = [ oid for oid in done if oid < oid_min ]
+
+        if len(greater):
+            self.raise_validation_error(f'some values in done are greater than {oid_max=}: {greater}')
+        if len(lesser):
+            self.raise_validation_error(f'some values in done are lesser than {oid_min=}: {lesser}')
+
+    def get_params_from_info(self, other_info):
+        oid_field_name, done_till, oid_max = other_info 
+        self.params = {
+            'oid_field_name': oid_field_name,
+            'oid_min': done_till + 1,
+            'oid_max': oid_max,
+            'done': []
+        }
+
+    def already_covered(self, feature):
+        oid_field_name = self.params['oid_field_name']
+        oid = feature['attributes'][oid_field_name]
+        return oid in self._done
+
+    def update(self, feature, *args):
+        oid_field_name = self.params['oid_field_name']
+        oid = feature['attributes'][oid_field_name]
+        self.params['done'].append(oid)
+        self._done.add(oid)
+        if oid > self._done_till:
+            self._done_till = oid
+
+    def update_from_geojson(self, f):
+        oid_field_name = self.params['oid_field_name']
+        oid = f['properties'][oid_field_name]
+        self.params['done'].append(oid)
+        self._done.add(oid)
+        if oid > self._done_till:
+            self._done_till = oid
+
+    def get_required_info(self):
+        return (self.params['oid_field_name'], self._done_till, self.params['oid_max'])
+
+    def __str__(self):
+        rep = super().__str__()
+        rep += f'done_till: {self._done_till}'
+        return rep
+
+    def desc_short(self):
+        desc = super().desc_short()
+        desc += f'params: < oid_field_name={self.params["oid_field_name"]}, oid_min={self.params["oid_min"]},\
+                            oid_max={self.params["oid_max"]}, done_till={self._done_till},\
+                            done_count={len(self.params["done"])} >'
+        return desc
+
+
+class OIDEnumerationDumperState(DumperState):
+    __params_schema = {
+        "type" : "object",
+        "required": [ "oid_field_name", "all_oids", "done" ],
+        "properties": {
+            "oid_field_name": {
+                "description": "name of the oid field",
+                "type": "string",
+            },
+            "all_oids": {
+                "description": "all the oid_field values in the layer",
+                "type": "array",
+                "items": {
+                    "type": "integer"
+                }
+            },
+            "done": {
+                "description": "oid_field values already seen",
+                "type": "array",
+                "items": {
+                    "type": "integer"
+                }
+            }
+        }
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._done = set(self.params['done'])
+
+    @property
+    def oids_left(self):
+        return [ oid for oid in self.params['all_oids'] if oid not in self._done ]
+
+    def validate_params(self):
+        super().validate_params()
+        # TODO: is this really needed?
+        all_oids_set = set(self.params['all_oids'])
+        done_set = set(self.params['done'])
+        extra_in_done = done_set - all_oids_set
+        if len(extra_in_done):
+            self.raise_validation_error(f'there are some oids in done set which are not in the oid list: {extra_in_done=}')
+        
+    def get_params_from_info(self, other_info):
+        oid_field_name, oids = other_info
+        self.params = {
+            'oid_field_name': oid_field_name,
+            'all_oids': oids,
+            'done': []
+        }
+
+    def already_covered(self, feature):
+        oid_field_name = self.params['oid_field_name']
+        oid = feature['attributes'][oid_field_name]
+        return oid in self._done
+
+    def update(self, feature, *args):
+        oid_field_name = self.params['oid_field_name']
+        oid = feature['attributes'][oid_field_name]
+        self.params['done'].append(oid)
+        self._done.add(oid)
+        
+    def update_from_geojson(self, f):
+        oid_field_name = self.params['oid_field_name']
+        oid = f['properties'][oid_field_name]
+        self.params['done'].append(oid)
+        self._done.add(oid)
+ 
+    def get_required_info(self):
+        return (self.params['oid_field_name'], self.oids_left)
+
+    def desc_short(self):
+        desc = super().desc_short()
+        desc += f'params: < oid_field_name={self.params["oid_field_name"]}, \
+                            all_oids_count={len(self.params["all_oids"])}, \
+                            done_count={len(self.params["done"])} >'
+        return desc
+
+
+class GeoQuery(Enum):
+    NOT_PRESENT = 0
+    OPEN = 1
+    SPLIT = 2
+    EXPLORED = 3
+
+class GeoQueryDumperState(DumperState):
+    __params_schema = {
+        "type" : "object",
+        "required": [ "oid_field_name", "explored_tree", "done" ],
+        "properties": {
+            "oid_field_name": {
+                "description": "name of the oid field",
+                "type": "string",
+            },
+            "explored_tree": {
+                "type": "object",
+                "description": "bounds tree and their exploration status",
+                "patternProperties": {
+                    "^[0-3]+$": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 3
+                    }
+                }
+            },
+            "id_type": {
+                "type": "string",
+                "description": "what is the type of id used in the 'done' array",
+                "enum": ["oid", "hash"]
+            },
+            "done": {
+                "description": "oid_field values already seen",
+                "type": "array",
+                "items": {
+                    "type": "integer"
+                }
+            }
+        }
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._done = set(self.params['done'])
+
+    def get_params_from_info(self, other_info):
+        self.params = {
+            'oid_field_name': other_info[0],
+            'explored_tree': {},
+            'done': []
+        }
+
+    def get_required_info(self):
+        return (self.params['oid_field_name'],)
+
+    def already_covered(self, feature):
+        oid_field_name = self.params['oid_field_name']
+        val = feature['attributes'][oid_field_name]
+        return val in self._done
+
+    def update_explored(self, key, val):
+        self.params['explored_tree'][key] = val.name
+        if val == GeoQuery.EXPLORED:
+            all_keys = list(self.params['explored_tree'].keys())
+            for k in all_keys:
+                if key == k:
+                    continue
+                if k.startswith(key):
+                    del self.params['explored_tree'][k]
+ 
+    def update(self, feature, *args):
+        if feature is None:
+            self.update_explored(args[0], args[1])
+            return
+        oid_field_name = self.params['oid_field_name']
+        oid = feature['attributes'][oid_field_name]
+        self.params['done'].append(oid)
+        self._done.add(oid)
+
+    def update_from_geojson(self, f):
+        oid_field_name = self.params['oid_field_name']
+        oid = f['properties'][oid_field_name]
+        self.params['done'].append(oid)
+        self._done.add(oid)
+ 
+    def desc_short(self):
+        desc = super().desc_short()
+        #TODO: add explored tree depth
+        desc += f'params: < oid_field_name={self.params["oid_field_name"]}, \
+                            done_count={len(self.params["done"])} >'
+        return desc
+
+
+
+class DumperMode(Enum):
+    NO_DATA = NoDataDumperState
+    RESULT_OFFSET = ResultOffsetDumperState
+    OID_WHERE_CLAUSE = OIDWhereClauseDumperState
+    OID_ENUMERATION = OIDEnumerationDumperState
+    GEO_QUERIES = GeoQueryDumperState

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     install_requires=[
         'requests',
         'six',
+        'jsonschema',
     ],
     entry_points={
         'console_scripts': ['esri2geojson=esridump.cli:main'],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,9 @@ class TestEsriDumpCommandlineMain(unittest.TestCase):
         self.parse_return.url = 'http://example.com'
         self.parse_return.outfile = self.mock_outfile
         self.parse_return.max_page_size = 1000
+        self.parse_return.pause_seconds = 0.01
+        self.parse_return.num_of_retry = 0
+        self.parse_return.requests_to_pause = 1000
         self.parse_return.loglevel = logging.ERROR
         self.parse_return.jsonlines = False
         self.parse_return.fields = None

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -14,6 +14,14 @@ class TestEsriDownload(unittest.TestCase):
 
         self.fake_url = 'http://example.com'
 
+
+    def get_dumper(self, **kwargs):
+        base_args = {
+            'pause_seconds': 0.01,
+        }
+        base_args.update(kwargs)
+        return EsriDumper(self.fake_url, **base_args)
+
     def tearDown(self):
         self.responses.stop()
         self.responses.reset()
@@ -50,7 +58,7 @@ class TestEsriDownload(unittest.TestCase):
             method='POST',
         )
 
-        dump = EsriDumper(self.fake_url)
+        dump = self.get_dumper()
         data = list(dump)
 
         self.assertEqual(6, len(data))
@@ -87,7 +95,7 @@ class TestEsriDownload(unittest.TestCase):
             method='POST',
         )
 
-        dump = EsriDumper(self.fake_url)
+        dump = self.get_dumper()
         data = list(dump)
 
         self.assertEqual(1, len(data))
@@ -109,7 +117,7 @@ class TestEsriDownload(unittest.TestCase):
             method='POST',
         )
 
-        dump = EsriDumper(self.fake_url)
+        dump = self.get_dumper()
         data = list(dump)
 
         self.assertEqual(1000, len(data))
@@ -146,7 +154,7 @@ class TestEsriDownload(unittest.TestCase):
             method='POST',
         )
 
-        dump = EsriDumper(self.fake_url)
+        dump = self.get_dumper()
         data = list(dump)
 
         self.assertEqual(15, len(data))
@@ -183,7 +191,7 @@ class TestEsriDownload(unittest.TestCase):
             method='POST',
         )
 
-        dump = EsriDumper(self.fake_url)
+        dump = self.get_dumper()
         data = list(dump)
 
         self.assertEqual(10, len(data))
@@ -215,7 +223,7 @@ class TestEsriDownload(unittest.TestCase):
             method='POST',
         )
 
-        dump = EsriDumper(self.fake_url)
+        dump = self.get_dumper()
         data = list(dump)
 
         self.assertEqual(15, len(data))
@@ -242,7 +250,7 @@ class TestEsriDownload(unittest.TestCase):
             method='POST',
         )
 
-        dump = EsriDumper(self.fake_url)
+        dump = self.get_dumper()
         data = list(dump)
 
         self.assertEqual(43, len(data))
@@ -269,7 +277,7 @@ class TestEsriDownload(unittest.TestCase):
             method='POST',
         )
 
-        dump = EsriDumper(self.fake_url, proxy='http://proxy?')
+        dump = self.get_dumper(proxy='http://proxy?')
         data = list(dump)
 
         self.assertEqual(43, len(data))
@@ -297,7 +305,7 @@ class TestEsriDownload(unittest.TestCase):
             body=socket.timeout(),
         )
 
-        dump = EsriDumper(self.fake_url)
+        dump = self.get_dumper()
         with self.assertRaisesRegex(EsriDownloadError, "Timeout when connecting to URL"):
             list(dump)
 
@@ -323,7 +331,7 @@ class TestEsriDownload(unittest.TestCase):
             body=ValueError(),
         )
 
-        dump = EsriDumper(self.fake_url)
+        dump = self.get_dumper()
         with self.assertRaisesRegex(EsriDownloadError, "Could not parse JSON"):
             list(dump)
 
@@ -349,7 +357,7 @@ class TestEsriDownload(unittest.TestCase):
             body=Exception(),
         )
 
-        dump = EsriDumper(self.fake_url, pause_seconds=0.01)
+        dump = self.get_dumper(pause_seconds=0.01)
         with self.assertRaisesRegex(EsriDownloadError, "Could not connect to URL"):
             list(dump)
 
@@ -395,7 +403,7 @@ class TestEsriDownload(unittest.TestCase):
             method='GET',
         )
 
-        dump = EsriDumper(self.fake_url)
+        dump = self.get_dumper()
         data = list(dump)
 
         # Note that this count is entirely fake because of the deduping happening
@@ -417,7 +425,7 @@ class TestEsriDownload(unittest.TestCase):
             method='GET',
         )
 
-        dump = EsriDumper(self.fake_url)
+        dump = self.get_dumper()
         data = list(dump)
 
         self.assertEqual(0, len(data))

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -18,6 +18,7 @@ class TestEsriDownload(unittest.TestCase):
     def get_dumper(self, **kwargs):
         base_args = {
             'pause_seconds': 0.01,
+            'max_page_size': 500,
         }
         base_args.update(kwargs)
         return EsriDumper(self.fake_url, **base_args)
@@ -454,4 +455,4 @@ class TestEsriDownload(unittest.TestCase):
 
         dump = EsriDumper(self.fake_url, output_format='esrijson')
         data = list(dump)
-        self.assertIn('attributes', data[0], message='Data does not have "attributes" key with output format == esrijson')
+        self.assertIn('attributes', data[0], 'Data does not have "attributes" key with output format == esrijson')


### PR DESCRIPTION
state can be serialised to disk and used to skip already handled features

Submitting the PR, to see if there is interest in this feature, given the amount of code changes, I wouldn't mind maintaining it separately if it is too much of a review burden.

TODO: 

- [ ]  Add tests for the state management code
- [ ]  provide support to specify state file in the cli
