### PR TITLE
Adds "output_format" option to toggle between GeoJSON and EsriJSON output

### DIFF
--- a/esridump/cli.py
+++ b/esridump/cli.py
@@ -80,6 +80,11 @@ def _parse_args(args):
         action='store_true',
         default=False,
         help="Turn on paginate by OID regardless of normal pagination support")
+    parser.add_argument("--output-format",
+        dest='output_format',
+        action='store',
+        default='geojson',
+        help="The JSON output format of the feature data")
 
     return parser.parse_args(args)
 
@@ -106,7 +111,8 @@ def main():
         timeout=args.timeout,
         max_page_size=args.max_page_size,
         parent_logger=logger,
-        paginate_oid=args.paginate_oid)
+        paginate_oid=args.paginate_oid,
+        output_format=args.output_format)
 
     if args.jsonlines:
         for feature in dumper:

--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -15,9 +15,9 @@ class EsriDumper(object):
                  timeout=None, fields=None, request_geometry=True,
                  outSR=None, proxy=None,
                  start_with=None, geometry_precision=None,
-                 paginate_oid=False,
-                 max_page_size=None,
-                 pause_seconds=10, requests_to_pause=5, num_of_retry=5):
+                 paginate_oid=False, max_page_size=None,
+                 pause_seconds=10, requests_to_pause=5,
+                 num_of_retry=5, output_format='geojson'):
         self._layer_url = url
         self._query_params = extra_query_args or {}
         self._headers = extra_headers or {}
@@ -34,6 +34,11 @@ class EsriDumper(object):
         self._pause_seconds = pause_seconds
         self._requests_to_pause = requests_to_pause
         self._num_of_retry = num_of_retry
+
+        if output_format not in ('geojson', 'esrijson'):
+            raise ValueError(f'Invalid output format. Expecting "geojson" or "esrijson", got {output_format}')
+
+        self._output_format = output_format
 
         if parent_logger:
             self._logger = parent_logger.getChild('esridump')
@@ -502,4 +507,7 @@ class EsriDumper(object):
             features = data.get('features')
 
             for feature in features:
-                yield esri2geojson(feature)
+                if self._output_format == 'geojson':
+                    yield esri2geojson(feature)
+                else:
+                    yield feature

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,7 @@ class TestEsriDumpCommandlineMain(unittest.TestCase):
         self.parse_return.headers = []
         self.parse_return.params = []
         self.parse_return.proxy = None
+        self.parse_return.output_format = 'geojson'
         self.mock_parseargs.return_value = self.parse_return
 
         self.fake_url = 'http://example.com'
@@ -108,3 +109,13 @@ class TestEsriDumpCommandlineMain(unittest.TestCase):
         self.assertIn('where=foo%3Dbar', self.responses.calls[2].request.url)
         self.assertIn('where=%28OBJECTID+%3E%3D+70193+AND+OBJECTID+%3C%3D+70307%29+AND+%28foo%3Dbar%29', self.responses.calls[3].request.body)
         self.assertEqual(self.mock_outfile.write.call_count, 14)
+
+    """
+    def test_esri_json_output(self):
+        self.parse_return.jsonlines = True
+
+        esridump.cli.main()
+
+        # jsonlines won't have FeatureCollection wrapper
+        self.assertEqual(self.mock_outfile.write.call_count, 12)
+    """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,13 +109,3 @@ class TestEsriDumpCommandlineMain(unittest.TestCase):
         self.assertIn('where=foo%3Dbar', self.responses.calls[2].request.url)
         self.assertIn('where=%28OBJECTID+%3E%3D+70193+AND+OBJECTID+%3C%3D+70307%29+AND+%28foo%3Dbar%29', self.responses.calls[3].request.body)
         self.assertEqual(self.mock_outfile.write.call_count, 14)
-
-    """
-    def test_esri_json_output(self):
-        self.parse_return.jsonlines = True
-
-        esridump.cli.main()
-
-        # jsonlines won't have FeatureCollection wrapper
-        self.assertEqual(self.mock_outfile.write.call_count, 12)
-    """

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -421,3 +421,29 @@ class TestEsriDownload(unittest.TestCase):
         data = list(dump)
 
         self.assertEqual(0, len(data))
+
+    def test_esri_json_output(self):
+        self.add_fixture_response(
+            r'.*/\?f=json.*',
+            'us-ca-carson/us-ca-carson-metadata.json',
+            method='GET',
+        )
+        self.add_fixture_response(
+            '.*returnCountOnly=true.*',
+            'us-ca-carson/us-ca-carson-count-only.json',
+            method='GET',
+        )
+        self.add_fixture_response(
+            '.*returnIdsOnly=true.*',
+            'us-ca-carson/us-ca-carson-ids-only.json',
+            method='GET',
+        )
+        self.add_fixture_response(
+            '.*query.*',
+            'us-ca-carson/us-ca-carson-0.json',
+            method='POST',
+        )
+
+        dump = EsriDumper(self.fake_url, output_format='esrijson')
+        data = list(dump)
+        self.assertIn('attributes', data[0], message='Data does not have "attributes" key with output format == esrijson')


### PR DESCRIPTION
## Summary of changes

Per issue #98, this PR intends to add an additional parameter to the `EsriDumper` class to allow yielding JSON in EsriJSON (the requested format). This functionality is toggled with an optional `output_format` flag accepting valid values "geojson" (default) and "esrijson".

Additionally, a test has been added to ensure no regressions were introduced.