### PR TITLE
Fix resultOffset method page_size and update example server

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ pip install esridump
 This module will install a command line utility called `esri2geojson` that accepts an Esri REST layer endpoint URL and a filename to write the output GeoJSON to:
 
 ```bash
-#esri2geojson http://cookviewer1.cookcountyil.gov/ArcGIS/rest/services/cookVwrDynmc/MapServer/11 cookcounty.geojson
 esri2geojson https://maps.six.nsw.gov.au/arcgis/rest/services/sixmaps/MaritimePublic/MapServer/13 martime_maps.geojson
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ pip install esridump
 This module will install a command line utility called `esri2geojson` that accepts an Esri REST layer endpoint URL and a filename to write the output GeoJSON to:
 
 ```bash
-esri2geojson http://cookviewer1.cookcountyil.gov/ArcGIS/rest/services/cookVwrDynmc/MapServer/11 cookcounty.geojson
+#esri2geojson http://cookviewer1.cookcountyil.gov/ArcGIS/rest/services/cookVwrDynmc/MapServer/11 cookcounty.geojson
+esri2geojson https://maps.six.nsw.gov.au/arcgis/rest/services/sixmaps/MaritimePublic/MapServer/13 martime_maps.geojson
 ```
 
 You can write to `stdout` by using the special output filename of `-` (a single dash character).

--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -330,7 +330,7 @@ class EsriDumper(object):
     def __iter__(self):
         query_fields = self._fields
         metadata = self.get_metadata()
-        page_size = min(self._max_page_size,
+        page_size = max(self._max_page_size,
                         metadata.get('maxRecordCount', 500))
         geometry_type = metadata.get('geometryType')
 

--- a/esridump/dumper.py
+++ b/esridump/dumper.py
@@ -373,7 +373,7 @@ class EsriDumper(object):
                 })
                 page_args.append(query_args)
             self._logger.info(
-                "Built %s requests using resultOffset method", len(page_args))
+                "Built %s requests of size %s using resultOffset method", len(page_args), page_size)
         else:
             # If not, we can still use the `where` argument to paginate
 


### PR DESCRIPTION
Calculation for resultOffset method was using min instead of max, resulting in a max page size of 1000 records when some services offer page sizes of 2000 or 4000 records.
Example service in README is no longer available. Updated to a service which has few records so is fast to download.